### PR TITLE
Reference to latest available issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ layout: default
   </div>
   <div class="cw-height-16"></div>
   <div class="cw-font-18">
-    You can read the latest issue from <a href="http://eepurl.com/bAx8tv" class="cw-link" target="_blank">here.</a>
+     A list of latest issues you can find <a href="http://us11.campaign-archive1.com/home/?u=d644228761eb9a81e877365cc&id=764dae5f03" class="cw-link" target="_blank">here</a>.
   </div>
   <div class="cw-height-40"></div>
   <div class="cw-white-background">


### PR DESCRIPTION
Not sure that this is a good idea to change a reference to the latest issue every week. As for me, that's much better just to link to the list of latest issues. I suppose campaign archive will show only some number of latest issues on [this](http://us11.campaign-archive1.com/home/?u=d644228761eb9a81e877365cc&id=764dae5f03) page. 

Unfortunately, that url is not shortened with [EepURL](http://eepurl.com/).
